### PR TITLE
Date type 

### DIFF
--- a/pickle/Date.java
+++ b/pickle/Date.java
@@ -1,0 +1,100 @@
+package pickle;
+
+public class Date {
+    private static final int[] iDaysPerMonth = new int[]{
+        0, 31, 29, 31, 30, 31, 30, 31, 31, 30 , 31, 30, 31
+    };
+    private static final String numbers = "0123456789";
+
+
+    private static int validateNumber(String date, int startIndex, int endIndex) throws PickleException {
+        String subStr = date.substring(startIndex, endIndex);
+
+        for (char c : subStr.toCharArray()) {
+            if (!numbers.contains(Character.toString(c))) {
+                throw new PickleException();
+            }
+        }
+
+        return Integer.parseInt(subStr);
+
+    }
+
+    public static boolean isLeapYear(int year) {
+        return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    }
+
+
+    public static ResultValue validateDate(String tokenStr) throws PickleException {
+        ResultValue res;
+
+        // first check for number of characters in String
+
+        // TODO: 4/19/2021 throw DateException Error
+        if (tokenStr.length() != 10)
+            throw new PickleException();
+
+        int year = validateNumber(tokenStr, 0, 4);
+
+        if (tokenStr.charAt(4) != '-' && tokenStr.charAt(7) != '-') {
+            throw new PickleException();
+        }
+
+        int month = validateNumber(tokenStr, 5, 7);
+
+        int day = validateNumber(tokenStr, 8, 10);
+
+        if (month < 1 || month > 12) {
+            throw  new PickleException();
+        }
+
+        if (day < 1 || day > iDaysPerMonth[month])
+            throw new PickleException();
+
+        res = new ResultValue(tokenStr, SubClassif.DATE);
+
+
+        if (day == 29 && month == 2) {
+            if (!isLeapYear(year)) {
+                // not correct date format
+                throw new PickleException();
+            }
+        }
+
+        return res;
+    }
+
+    private static int dateToJulian(String dateStr) throws PickleException {
+        int year = validateNumber(dateStr, 0, 4);
+        int month = validateNumber(dateStr, 5, 7);
+        int day = validateNumber(dateStr, 8, 10);
+
+        if (month > 2) {
+            month = month - 3;
+        } else {
+            month = month + 9;
+            year = year - 1;
+        }
+
+        return 365 * year + year / 4 - year / 100 + year / 400 + (month * 306 + 5) / 10 + (day);
+    }
+
+
+
+    public static ResultValue dateDiff(ResultValue date1, ResultValue date2) throws PickleException {
+        if (date1.dataType != SubClassif.DATE) {
+            date1 = validateDate(date1.strValue);
+        }
+
+        if (date2.dataType != SubClassif.DATE) {
+            date2 = validateDate(date2.strValue);
+        }
+
+        int julian1 = dateToJulian(date1.strValue);
+        int julian2 = dateToJulian(date2.strValue);
+
+
+        return new ResultValue(String.valueOf(julian1 - julian2), SubClassif.INTEGER);
+
+    }
+}

--- a/pickle/Date.java
+++ b/pickle/Date.java
@@ -137,4 +137,27 @@ public class Date {
         return validateDate(newDate);
 
     }
+
+
+    public static ResultValue dateAge(ResultValue date1, ResultValue date2) throws PickleException {
+        if (date1.dataType != SubClassif.DATE)
+            date1 = validateDate(date1.strValue);
+
+        if (date2.dataType != SubClassif.DATE)
+            date2 = validateDate(date2.strValue);
+
+        int date1Year = validateNumber(date1.strValue, 0, 4);
+        int date1Month = validateNumber(date1.strValue, 5, 7);
+
+        int date2Year = validateNumber(date2.strValue, 0, 4);
+        int date2Month = validateNumber(date2.strValue, 5, 7);
+
+        int out = date1Year - date2Year;
+
+        if (date1Month < date2Month) {
+            out--;
+        }
+
+        return new ResultValue(String.valueOf(out), SubClassif.INTEGER);
+    }
 }

--- a/pickle/Date.java
+++ b/pickle/Date.java
@@ -101,11 +101,9 @@ public class Date {
         int julian1 = dateToJulian(date1.strValue);
         int julian2 = dateToJulian(date2.strValue);
 
-        System.out.printf("Date 1 str: %d; Date 2 str: %d\n", julian1, julian2);
-
+        //System.out.printf("Date 1 str: %d; Date 2 str: %d\n", julian1, julian2);
 
         return new ResultValue(String.valueOf(julian1 - julian2), SubClassif.INTEGER);
-
     }
 
 

--- a/pickle/Date.java
+++ b/pickle/Date.java
@@ -1,5 +1,9 @@
 package pickle;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
 public class Date {
     private static final int[] iDaysPerMonth = new int[]{
         0, 31, 29, 31, 30, 31, 30, 31, 31, 30 , 31, 30, 31
@@ -76,7 +80,11 @@ public class Date {
             year = year - 1;
         }
 
-        return 365 * year + year / 4 - year / 100 + year / 400 + (month * 306 + 5) / 10 + (day);
+        return 365 * year
+                + year / 4 - year / 100
+                + year / 400
+                + (month * 306 + 5) / 10
+                + (day);
     }
 
 
@@ -93,8 +101,40 @@ public class Date {
         int julian1 = dateToJulian(date1.strValue);
         int julian2 = dateToJulian(date2.strValue);
 
+        System.out.printf("Date 1 str: %d; Date 2 str: %d\n", julian1, julian2);
+
 
         return new ResultValue(String.valueOf(julian1 - julian2), SubClassif.INTEGER);
+
+    }
+
+
+    public static ResultValue dateAdj(ResultValue date, ResultValue adjValue) throws PickleException {
+        if (date.dataType != SubClassif.DATE) {
+            date = validateDate(date.strValue);
+        }
+        if (adjValue.dataType != SubClassif.INTEGER) {
+            throw new PickleException();
+        }
+
+        SimpleDateFormat sDF = new SimpleDateFormat("yyy-MM-dd");
+
+        Calendar calendar = Calendar.getInstance();
+
+        try {
+            calendar.setTime(sDF.parse(date.strValue));
+        } catch (ParseException e) {
+           throw new PickleException();
+        }
+
+        calendar.add(Calendar.DAY_OF_MONTH, Integer.parseInt(adjValue.strValue));
+
+
+        String newDate = sDF.format(calendar.getTime());
+
+
+
+        return validateDate(newDate);
 
     }
 }

--- a/pickle/Expr.java
+++ b/pickle/Expr.java
@@ -366,12 +366,16 @@ public class Expr {
                                 }
                                 STIdentifier id = (STIdentifier) entry;
 
-                                if (id.dclType != SubClassif.DATE) {
+                                if (id.dclType != SubClassif.DATE && id.dclType != SubClassif.STRING) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-date value with dateDiff function");
                                 }
 
                                 try {
                                     param = (ResultValue) parser.storageManager.getVariable(id.symbol);
+
+                                    if (id.dclType == SubClassif.STRING) {
+                                        param = Date.validateDate(param.strValue);
+                                    }
                                 } catch (Exception e) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
                                 }
@@ -389,12 +393,16 @@ public class Expr {
                                 }
                                 STIdentifier id = (STIdentifier) entry;
 
-                                if (id.dclType != SubClassif.DATE) {
+                                if (id.dclType != SubClassif.DATE && id.dclType != SubClassif.STRING) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-date value with dateDiff function");
                                 }
 
                                 try {
                                     param2 = (ResultValue) parser.storageManager.getVariable(id.symbol);
+
+                                    if (id.dclType == SubClassif.STRING) {
+                                        param2 = Date.validateDate(param2.strValue);
+                                    }
                                 } catch (Exception e) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
                                 }
@@ -423,12 +431,16 @@ public class Expr {
                                 }
                                 STIdentifier id = (STIdentifier) entry;
 
-                                if (id.dclType != SubClassif.DATE) {
+                                if (id.dclType != SubClassif.DATE && id.dclType != SubClassif.STRING) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-date value with dateDiff function");
                                 }
 
                                 try {
                                     param = (ResultValue) parser.storageManager.getVariable(id.symbol);
+
+                                    if (id.dclType == SubClassif.STRING) {
+                                        param = Date.validateDate(param.strValue);
+                                    }
                                 } catch (Exception e) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
                                 }
@@ -460,6 +472,72 @@ public class Expr {
                             }
 
                             res = Date.dateAdj(param, param2);
+                            break;
+
+                        case "dateAge":
+                            if ( stack.size() < 2) {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Did not supply enough parameters for function");
+                            }
+
+                            param2 = stack.pop();
+                            param = stack.pop();
+
+                            if (param.dataType == SubClassif.IDENTIFIER) {
+                                STEntry entry = parser.symbolTable.getSymbol(param.strValue);
+
+                                if (entry.primClassif == Classif.EMPTY) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Identifier must be initilized");
+                                }
+                                STIdentifier id = (STIdentifier) entry;
+
+                                if (id.dclType != SubClassif.DATE && id.dclType != SubClassif.STRING) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-date value with dateDiff function");
+                                }
+
+                                try {
+                                    param = (ResultValue) parser.storageManager.getVariable(id.symbol);
+
+                                    if (id.dclType == SubClassif.STRING) {
+                                        param = Date.validateDate(param.strValue);
+                                    }
+                                } catch (Exception e) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
+                                }
+                            } else if (param.dataType == SubClassif.STRING) {
+                                param = Date.validateDate(param.strValue);
+                            } else {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
+                            }
+
+                            if (param2.dataType == SubClassif.IDENTIFIER) {
+                                STEntry entry = parser.symbolTable.getSymbol(param2.strValue);
+
+                                if (entry.primClassif == Classif.EMPTY) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Identifier must be initilized");
+                                }
+                                STIdentifier id = (STIdentifier) entry;
+
+                                if (id.dclType != SubClassif.DATE && id.dclType != SubClassif.STRING) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-date value with dateDiff function");
+                                }
+
+                                try {
+                                    param2 = (ResultValue) parser.storageManager.getVariable(id.symbol);
+
+                                    if (id.dclType == SubClassif.STRING) {
+                                        param2 = Date.validateDate(param2.strValue);
+                                    }
+                                } catch (Exception e) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
+                                }
+                            } else if (param2.dataType == SubClassif.STRING) {
+                                param2 = Date.validateDate(param2.strValue);
+                            } else {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
+                            }
+
+                            res = Date.dateAge(param, param2);
+
                             break;
 
                         default:

--- a/pickle/Expr.java
+++ b/pickle/Expr.java
@@ -380,7 +380,7 @@ public class Expr {
                                 } catch (Exception e) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
                                 }
-                            } else if (param.dataType == SubClassif.STRING) {
+                            } else if (param.dataType == SubClassif.STRING || param.dataType == SubClassif.DATE) {
                                 param = Date.validateDate(param.strValue);
                             } else {
                                 throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
@@ -407,7 +407,7 @@ public class Expr {
                                 } catch (Exception e) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
                                 }
-                            } else if (param2.dataType == SubClassif.STRING) {
+                            } else if (param2.dataType == SubClassif.STRING || param2.dataType == SubClassif.DATE) {
                                 param2 = Date.validateDate(param2.strValue);
                             } else {
                                 throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
@@ -445,7 +445,7 @@ public class Expr {
                                 } catch (Exception e) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
                                 }
-                            } else if (param.dataType == SubClassif.STRING) {
+                            } else if (param.dataType == SubClassif.STRING || param.dataType == SubClassif.DATE) {
                                 param = Date.validateDate(param.strValue);
                             } else {
                                 throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
@@ -504,7 +504,7 @@ public class Expr {
                                 } catch (Exception e) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
                                 }
-                            } else if (param.dataType == SubClassif.STRING) {
+                            } else if (param.dataType == SubClassif.STRING || param.dataType == SubClassif.DATE) {
                                 param = Date.validateDate(param.strValue);
                             } else {
                                 throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
@@ -531,7 +531,7 @@ public class Expr {
                                 } catch (Exception e) {
                                     throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
                                 }
-                            } else if (param2.dataType == SubClassif.STRING) {
+                            } else if (param2.dataType == SubClassif.STRING || param2.dataType == SubClassif.DATE) {
                                 param2 = Date.validateDate(param2.strValue);
                             } else {
                                 throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");

--- a/pickle/Expr.java
+++ b/pickle/Expr.java
@@ -9,12 +9,17 @@ public class Expr {
         ArrayList<Token> postfix = new ArrayList<Token>();
         Stack<Token> stack = new Stack<Token>();
 
-        while(!parser.scanner.currentToken.tokenStr.equals(",")
-                && !parser.scanner.currentToken.tokenStr.equals(";")
+        int funcBool = 0;
+
+        while(     !parser.scanner.currentToken.tokenStr.equals(";")
                 && !parser.scanner.currentToken.tokenStr.equals(":")
                 && !parser.scanner.currentToken.tokenStr.equals("to")
                 && !parser.scanner.currentToken.tokenStr.equals("by")
                 && !parser.scanner.currentToken.tokenStr.equals("=")) {
+
+            if (funcBool == 0 && parser.scanner.currentToken.tokenStr.equals(",")) {
+                break;
+            }
 
             switch (parser.scanner.currentToken.primClassif) {
                 case OPERAND:
@@ -79,6 +84,7 @@ public class Expr {
                                         popped = stack.pop();
                                     }
                                     stack.push(popped);
+                                    funcBool--;
                                 }
                                 break;
                             case "]":
@@ -104,6 +110,7 @@ public class Expr {
                         break;
                 case FUNCTION:
                         stack.push(parser.scanner.currentToken);
+                        funcBool++;
                         if (!parser.scanner.getNext().equals("(")) {
                             throw new ScannerParserException(parser.scanner.currentToken, parser.scanner.sourceFileNm, "Functions must be followed by a '(' token");
                         }
@@ -222,6 +229,7 @@ public class Expr {
 
                 case FUNCTION:
                     ResultValue param;
+                    ResultValue param2;
                     ResultList paramM;
                     switch (token.tokenStr) {
                         case "LENGTH":
@@ -340,6 +348,118 @@ public class Expr {
                             } else {
                                 throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value of variable cannot be array");
                             }
+                            break;
+
+                        case "dateDiff":
+                            if ( stack.size() < 2) {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Did not supply enough parameters for function");
+                            }
+
+                            param2 = stack.pop();
+                            param = stack.pop();
+
+                            if (param.dataType == SubClassif.IDENTIFIER) {
+                                STEntry entry = parser.symbolTable.getSymbol(param.strValue);
+
+                                if (entry.primClassif == Classif.EMPTY) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Identifier must be initilized");
+                                }
+                                STIdentifier id = (STIdentifier) entry;
+
+                                if (id.dclType != SubClassif.DATE) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-date value with dateDiff function");
+                                }
+
+                                try {
+                                    param = (ResultValue) parser.storageManager.getVariable(id.symbol);
+                                } catch (Exception e) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
+                                }
+                            } else if (param.dataType == SubClassif.STRING) {
+                                param = Date.validateDate(param.strValue);
+                            } else {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
+                            }
+
+                            if (param2.dataType == SubClassif.IDENTIFIER) {
+                                STEntry entry = parser.symbolTable.getSymbol(param2.strValue);
+
+                                if (entry.primClassif == Classif.EMPTY) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Identifier must be initilized");
+                                }
+                                STIdentifier id = (STIdentifier) entry;
+
+                                if (id.dclType != SubClassif.DATE) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-date value with dateDiff function");
+                                }
+
+                                try {
+                                    param2 = (ResultValue) parser.storageManager.getVariable(id.symbol);
+                                } catch (Exception e) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
+                                }
+                            } else if (param2.dataType == SubClassif.STRING) {
+                                param2 = Date.validateDate(param2.strValue);
+                            } else {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
+                            }
+
+                            res = Date.dateDiff(param, param2);
+
+                            break;
+                        case "dateAdj":
+                            if ( stack.size() < 2) {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Did not supply enough parameters for function");
+                            }
+
+                            param2 = stack.pop();
+                            param = stack.pop();
+
+                            if (param.dataType == SubClassif.IDENTIFIER) {
+                                STEntry entry = parser.symbolTable.getSymbol(param.strValue);
+
+                                if (entry.primClassif == Classif.EMPTY) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Identifier must be initilized");
+                                }
+                                STIdentifier id = (STIdentifier) entry;
+
+                                if (id.dclType != SubClassif.DATE) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-date value with dateDiff function");
+                                }
+
+                                try {
+                                    param = (ResultValue) parser.storageManager.getVariable(id.symbol);
+                                } catch (Exception e) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
+                                }
+                            } else if (param.dataType == SubClassif.STRING) {
+                                param = Date.validateDate(param.strValue);
+                            } else {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Date constant or variable. Could not convert to date");
+                            }
+
+                            if (param2.dataType == SubClassif.IDENTIFIER) {
+                                STEntry entry = parser.symbolTable.getSymbol(param2.strValue);
+
+                                if (entry.primClassif == Classif.EMPTY) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Identifier must be initialized");
+                                }
+                                STIdentifier id = (STIdentifier) entry;
+
+                                if (id.dclType != SubClassif.INTEGER) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use non-integer value with dateAdj function");
+                                }
+
+                                try {
+                                    param2 = (ResultValue) parser.storageManager.getVariable(id.symbol);
+                                } catch (Exception e) {
+                                    throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Cannot use array value with dateDiff function");
+                                }
+                            } else if (param2.dataType != SubClassif.INTEGER) {
+                                throw new ScannerParserException(token, parser.scanner.sourceFileNm, "Value was not Integer constant or variable");
+                            }
+
+                            res = Date.dateAdj(param, param2);
                             break;
 
                         default:

--- a/pickle/Expr.java
+++ b/pickle/Expr.java
@@ -184,7 +184,8 @@ public class Expr {
 
 
 
-                        } else if (entry.primClassif != Classif.EMPTY && ((STIdentifier) entry).dclType == SubClassif.STRING) {
+                        } else if (entry.primClassif != Classif.EMPTY &&
+                                (((STIdentifier) entry).dclType == SubClassif.STRING || ((STIdentifier)entry).dclType == SubClassif.DATE)) {
                             ResultValue index = stack.pop();
 
                             try {

--- a/pickle/Parser.java
+++ b/pickle/Parser.java
@@ -812,21 +812,30 @@ public class Parser {
 
 
                 try {
-                    STIdentifier entry = (STIdentifier) this.symbolTable.getSymbol(scanner.nextToken.tokenStr);
+                    if (scanner.nextToken.subClassif == SubClassif.IDENTIFIER) {
+                        //STIdentifier entry = (STIdentifier) this.symbolTable.getSymbol(scanner.nextToken.tokenStr);
+                        STEntry entry = this.symbolTable.getSymbol(scanner.nextToken.tokenStr);
 
-                    if (entry.primClassif == Classif.EMPTY) {
-                        throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Identifier must be declared first");
-                    }
-
-                    if (entry.dclType == SubClassif.STRING && !entry.structure.equals("array")) {
+                        if (entry.primClassif != Classif.EMPTY) {
+                            STIdentifier id = (STIdentifier) entry;
+                            if ((id.dclType == SubClassif.STRING || id.dclType == SubClassif.DATE) && !id.structure.equals("array")) {
+                                charStringFor(controlVar);
+                            } else if (id.structure.equals("array")) {
+                                itemArrayFor(controlVar);
+                            } else {
+                                // TODO: 4/15/2021 cannot run for loop on any other types
+                                throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Identifier must be of type String, Int, Float to use for loop");
+                            }
+                        } else {
+                            throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Cannot find value for Identifier");
+                        }
+                    }else if (scanner.nextToken.subClassif == SubClassif.STRING || scanner.nextToken.subClassif == SubClassif.DATE) {
                         charStringFor(controlVar);
+                    } else {
+                        throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Cannot run for loop on constant value " + scanner.nextToken.subClassif.name());
                     }
-                    else if (entry.structure.equals("array")) {
-                        itemArrayFor(controlVar);
-                    } else  {
-                        // TODO: 4/15/2021 cannot run for loop on any other types
-                        throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Identifier must be of type String, Int, Float to use for loop");
-                    }
+
+
                 } catch (PickleException p) {
                     throw p;
                 } catch (Exception e) {
@@ -888,10 +897,10 @@ public class Parser {
             throw new ScannerParserException(scanner.currentToken, scanner.sourceFileNm, "Cannot use for char loop over array");
         }
 
-        if (limit.dataType != SubClassif.STRING) {
+        /*if (limit.dataType != SubClassif.STRING) {
             //TODO fix exception - limit type needs to be of a string
             throw new PickleException();
-        }
+        }*/
 
         ResultValue startValue = Utility.valueAtIndex(this, limit, 0); //set up iterating char value
 

--- a/pickle/Parser.java
+++ b/pickle/Parser.java
@@ -141,6 +141,10 @@ public class Parser {
         if (scanner.getNext().equals("=")) {
             scanner.getNext();
             res = (ResultValue) expr();
+
+            if (declareTypeStr.equals("Date")) {
+                res = Date.validateDate(res.strValue);
+            }
         }
 
         // Statement does not end in a semicolon
@@ -1249,10 +1253,10 @@ public class Parser {
                 return SubClassif.BOOLEAN;
             case "String":
                 return SubClassif.STRING;
-            case "pickle.Date":
+            case "Date":
                 return SubClassif.DATE;
             default:
-                throw new PickleException();
+                throw new ScannerParserException(scanner.currentToken, scanner.sourceFileNm, "Invalid Declaration type");
         }
     }
 }

--- a/pickle/Parser.java
+++ b/pickle/Parser.java
@@ -1249,7 +1249,7 @@ public class Parser {
                 return SubClassif.BOOLEAN;
             case "String":
                 return SubClassif.STRING;
-            case "Date":
+            case "pickle.Date":
                 return SubClassif.DATE;
             default:
                 throw new PickleException();

--- a/pickle/Parser.java
+++ b/pickle/Parser.java
@@ -282,7 +282,7 @@ public class Parser {
 
                 if (entry.primClassif == Classif.EMPTY) {
                     throw new ScannerParserException(scanner.currentToken, scanner.sourceFileNm, "Cannot index into uninitialized string");
-                } else  if (((STIdentifier)entry).dclType != SubClassif.STRING) {
+                } else  if (((STIdentifier)entry).dclType != SubClassif.STRING && ((STIdentifier)entry).dclType != SubClassif.DATE) {
                     throw new ScannerParserException(scanner.currentToken, scanner.sourceFileNm, "Cannot index into non array or non string variables");
                 }
 
@@ -305,6 +305,8 @@ public class Parser {
 
                 res = Utility.assignAtIndex(this, str, (ResultValue) res, Integer.parseInt(index.strValue) );
 
+            } catch (PickleException p) {
+                throw p;
             } catch (Exception e) {
                 throw new ScannerParserException(scanner.currentToken, scanner.sourceFileNm, "Expression must be scalar value");
             }

--- a/pickle/SymbolTable.java
+++ b/pickle/SymbolTable.java
@@ -66,7 +66,7 @@ public class SymbolTable {
 		this.globalST.put("Float", new STControl("Float", Classif.CONTROL, SubClassif.DECLARE));
 		this.globalST.put("String", new STControl("String", Classif.CONTROL, SubClassif.DECLARE));
 		this.globalST.put("Bool", new STControl("Bool", Classif.CONTROL, SubClassif.DECLARE));
-		this.globalST.put("Date", new STControl("Date", Classif.CONTROL, SubClassif.DECLARE));
+		this.globalST.put("pickle.Date", new STControl("pickle.Date", Classif.CONTROL, SubClassif.DECLARE));
 
 		this.globalST.put("and", new STEntry("and", Classif.OPERATOR));
 		this.globalST.put("or", new STEntry("or", Classif.OPERATOR));

--- a/pickle/SymbolTable.java
+++ b/pickle/SymbolTable.java
@@ -82,6 +82,7 @@ public class SymbolTable {
 		this.globalST.put("MAXELEM", new STFunction("MAXELEM", Classif.FUNCTION, SubClassif.INTEGER, SubClassif.BUILTIN, 1));		//TODO: acutal number?
 		this.globalST.put("dateDiff", new STFunction("dateDiff", Classif.FUNCTION, SubClassif.INTEGER, SubClassif.BUILTIN, 2));
 		this.globalST.put("dateAdj", new STFunction("dateAdj", Classif.FUNCTION, SubClassif.DATE, SubClassif.BUILTIN, 2));
+		this.globalST.put("dateAge", new STFunction("dateAge", Classif.FUNCTION, SubClassif.INTEGER, SubClassif.BUILTIN, 2));
 	}
 
 }

--- a/pickle/SymbolTable.java
+++ b/pickle/SymbolTable.java
@@ -66,7 +66,7 @@ public class SymbolTable {
 		this.globalST.put("Float", new STControl("Float", Classif.CONTROL, SubClassif.DECLARE));
 		this.globalST.put("String", new STControl("String", Classif.CONTROL, SubClassif.DECLARE));
 		this.globalST.put("Bool", new STControl("Bool", Classif.CONTROL, SubClassif.DECLARE));
-		this.globalST.put("pickle.Date", new STControl("pickle.Date", Classif.CONTROL, SubClassif.DECLARE));
+		this.globalST.put("Date", new STControl("Date", Classif.CONTROL, SubClassif.DECLARE));
 
 		this.globalST.put("and", new STEntry("and", Classif.OPERATOR));
 		this.globalST.put("or", new STEntry("or", Classif.OPERATOR));

--- a/pickle/SymbolTable.java
+++ b/pickle/SymbolTable.java
@@ -80,6 +80,8 @@ public class SymbolTable {
 		this.globalST.put("SPACES", new STFunction("SPACES", Classif.FUNCTION, SubClassif.INTEGER, SubClassif.BUILTIN, 0));			//TODO: acutal number?
 		this.globalST.put("ELEM", new STFunction("ELEM", Classif.FUNCTION, SubClassif.INTEGER, SubClassif.BUILTIN, 1));				//TODO: acutal number?
 		this.globalST.put("MAXELEM", new STFunction("MAXELEM", Classif.FUNCTION, SubClassif.INTEGER, SubClassif.BUILTIN, 1));		//TODO: acutal number?
+		this.globalST.put("dateDiff", new STFunction("dateDiff", Classif.FUNCTION, SubClassif.INTEGER, SubClassif.BUILTIN, 2));
+		this.globalST.put("dateAdj", new STFunction("dateAdj", Classif.FUNCTION, SubClassif.DATE, SubClassif.BUILTIN, 2));
 	}
 
 }

--- a/pickle/tests/DateTest.java
+++ b/pickle/tests/DateTest.java
@@ -1,0 +1,157 @@
+package pickle.tests;
+
+import org.junit.jupiter.api.Test;
+import pickle.Date;
+import pickle.PickleException;
+import pickle.ResultValue;
+import pickle.SubClassif;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DateTest {
+
+    private final String[] goodDateStrings = new String[] {
+            "2017-04-01",
+            "2015-05-01",
+            "2017-02-01",
+            "2015-02-01",
+            "2017-02-01",
+            "1957-12-04",
+            "1953-12-12",
+            "2016-12-31",
+            "2016-02-29",
+            "1995-07-09"
+    } ;
+
+    private final int[] goodDateDiff = new int[] {
+            701,
+            -642,
+            731,
+            -731,
+            21609,
+            1453,
+            -23030,
+            306,
+            7540
+    };
+
+    private final int[] goodNumberStrings = new int[] {
+            2017,
+            2015,
+            2017,
+            2015,
+            2017,
+            1957,
+            1953,
+            2016,
+            2016
+    };
+
+    private final String[] badDateStrings = new String[] {
+            "2015-02-29",
+            "2016-06-31",
+            "2016-12-31A",
+            "2016-12-3100",
+            "2016-1212-31"
+    };
+
+    private final int[] leapYears = new int[] {
+            2016,
+            2020,
+            2012,
+            2008,
+            2004
+    };
+
+    private final int[] nonLeapYears = new int[] {
+            1900,
+            2002,
+            2010,
+            2021,
+            2017
+    };
+
+
+
+
+    @Test
+    void isLeapYear() {
+
+        for (int year : leapYears) {
+            assertTrue(Date.isLeapYear(year));
+        }
+
+        for (int year : nonLeapYears) {
+            assertFalse(Date.isLeapYear(year), "Failed on date " + year);
+        }
+    }
+
+    @Test
+    void validateDate() {
+
+        for (String date : goodDateStrings) {
+            ResultValue expectedResult = new ResultValue(date, SubClassif.DATE);
+
+
+
+            assertDoesNotThrow(() ->{
+                ResultValue receivedResult = Date.validateDate(date);
+
+                assertEquals(expectedResult.strValue, receivedResult.strValue);
+                assertEquals(expectedResult.dataType, receivedResult.dataType);
+            }, "Error on year: " + date);
+
+
+        }
+
+        for (String date : badDateStrings) {
+
+            assertThrows(PickleException.class, () -> Date.validateDate(date));
+
+        }
+    }
+
+
+    @Test
+    void dateDiff() {
+        for (int i = 0; i < goodDateStrings.length - 1; i++) {
+
+            final int index = i;
+            ResultValue expected = new ResultValue(String.valueOf(goodDateDiff[index]*-1), SubClassif.INTEGER);
+
+
+            assertDoesNotThrow(() -> {
+                ResultValue date1 = new ResultValue(goodDateStrings[index], SubClassif.DATE);
+                ResultValue date2 = new ResultValue(goodDateStrings[index+1], SubClassif.DATE );
+
+                ResultValue received = Date.dateDiff(date1, date2);
+
+                assertEquals(expected.strValue, received.strValue, "Error on dates: " + date1.strValue + " " + date2.strValue + "; Expected: " + expected.strValue + "; Received: " + received.strValue);
+                assertEquals(expected.dataType, received.dataType, "Error on dates: " + date1.strValue + " " + date2.strValue + "; Expected: " + expected.dataType.name() + "; Received: " + received.dataType.name());
+
+            });
+        }
+
+    }
+
+
+    @Test
+    void dateAdj() {
+        for (int i = 0; i < goodDateStrings.length - 1; i++) {
+
+            final int index = i;
+            ResultValue expected = new ResultValue(goodDateStrings[index+1], SubClassif.DATE );
+
+            assertDoesNotThrow(() -> {
+                ResultValue date = new ResultValue(goodDateStrings[index], SubClassif.DATE);
+                ResultValue adjValue = new ResultValue(String.valueOf(goodDateDiff[index]*-1), SubClassif.INTEGER);
+
+                ResultValue received = Date.dateAdj(date, adjValue);
+
+                assertEquals(expected.strValue, received.strValue, "Error on date : " + date.strValue + ", " + expected.strValue + "; Expected: " + expected.strValue + "; Received: " + received.strValue);
+                assertEquals(expected.dataType, received.dataType, "Error on date : " + date.strValue + ", " + expected.strValue + "; Expected: " + expected.dataType.name() + "; Received: " + received.dataType.name());
+
+            });
+        }
+    }
+}

--- a/pickle/tests/DateTest.java
+++ b/pickle/tests/DateTest.java
@@ -23,6 +23,8 @@ class DateTest {
             "1995-07-09"
     } ;
 
+
+
     private final int[] goodDateDiff = new int[] {
             701,
             -642,
@@ -117,7 +119,7 @@ class DateTest {
         for (int i = 0; i < goodDateStrings.length - 1; i++) {
 
             final int index = i;
-            ResultValue expected = new ResultValue(String.valueOf(goodDateDiff[index]*-1), SubClassif.INTEGER);
+            ResultValue expected = new ResultValue(String.valueOf(goodDateDiff[index]), SubClassif.INTEGER);
 
 
             assertDoesNotThrow(() -> {
@@ -153,5 +155,23 @@ class DateTest {
 
             });
         }
+    }
+
+
+    @Test
+    void dateAge() {
+        ResultValue expected = new ResultValue("2", SubClassif.INTEGER);
+
+        assertDoesNotThrow(() -> {
+            ResultValue date1 = new ResultValue("2017-02-01", SubClassif.STRING);
+            ResultValue date2 = new ResultValue("2015-02-01", SubClassif.STRING);
+
+            ResultValue received = Date.dateAge(date1, date2);
+
+            assertEquals(expected.strValue, received.strValue, "Error on dates: " + date1.strValue + " " + date2.strValue + "; Expected: " + expected.strValue + "; Received: " + received.strValue);
+            assertEquals(expected.dataType, received.dataType, "Error on dates: " + date1.strValue + " " + date2.strValue + "; Expected: " + expected.dataType.name() + "; Received: " + received.dataType.name());
+
+
+        });
     }
 }


### PR DESCRIPTION
Add functionality for date type conversion that match the exact patter "YYYY-MM-DD". Add builtin functions (all functions accept Date or coerced strings as parameters) will close #37 

 - dateDiff
    - returns number of days between two date types (accounts for leap years)
 - dateAdj
    - returns a date adjusted by some number of days given as a parameter
 - dateAge
    - returns the number of years passed between two dates

 All p4 text files produce correct output and working p5Date output
```
p5Date.txt 
Date 1 str: 736726; Date 2 str: 735995
date1 = 2017-04-01 date2 = 2015-04-01 diff = 731 
date = 2017-04-01 adjusted by 1 = 2017-04-02 
date = 2017-04-01 adjusted by -40 = 2017-02-20 
date = 2017-04-01 adjusted by -365 = 2016-04-01 
date = 2017-04-01 adjusted by -731 = 2015-04-01 
date1 = 2017-02-01 date2 = 2015-02-01 age = 2 
date1 = 2017-02-01 date2 = 1957-12-04 age = 59 
date1 = 2017-02-01 date2 = 1953-12-12 age = 63 

Process finished with exit code 0
```