### PR TITLE
Feature/break continue

### DIFF
--- a/pickle/Parser.java
+++ b/pickle/Parser.java
@@ -884,10 +884,10 @@ public class Parser {
                     }
 
                     if (entry.dclType == SubClassif.STRING && !entry.structure.equals("array")) {
-                        charStringFor(controlVar, execMode);
+                        result = charStringFor(controlVar, execMode);
                     }
                     else if (entry.structure.equals("array")) {
-                        itemArrayFor(controlVar, execMode);
+                        result = itemArrayFor(controlVar, execMode);
                     } else  {
                         // TODO: 4/15/2021 cannot run for loop on any other types
                         throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Identifier must be of type String, Int, Float to use for loop");
@@ -927,6 +927,7 @@ public class Parser {
     private ResultValue charStringFor(String controlVar, iExecMode execMode) throws PickleException {
         STEntry entry = symbolTable.getSymbol(controlVar);
         ResultValue result = new ResultValue("", SubClassif.EMPTY);
+        result.execMode = execMode;
 
         if (entry.primClassif == Classif.EMPTY) {
             symbolTable.putSymbol(controlVar,
@@ -979,7 +980,8 @@ public class Parser {
         Numeric nOp1, nOp2;
         nOp2 = new Numeric(this, incrementBy, "+", "Incrementing by value");
 
-        while(Utility.lessThan(this, currPos, maxPos).strValue.equals("T")) {
+        while(Utility.lessThan(this, currPos, maxPos).strValue.equals("T") &&
+                (result.execMode == iExecMode.EXECUTE || result.execMode == iExecMode.CONTINUE_EXEC)) {
             // evaluate loop statements
             result = statements(execMode);
 
@@ -1003,6 +1005,7 @@ public class Parser {
         }
 
         result = statements(iExecMode.IGNORE_EXEC);
+        result.execMode = execMode;
 
         if (!result.terminatingString.equals("endfor")) {
             //TODO: fix exception - end should be here
@@ -1020,14 +1023,15 @@ public class Parser {
     private ResultValue itemArrayFor(String controlVar, iExecMode execMode) throws  PickleException {
         STEntry entry = symbolTable.getSymbol(controlVar);
         ResultValue result = new ResultValue("", SubClassif.EMPTY);
-
+        result.execMode = execMode;
+        ResultValue startValue; //set up iterating char value
+        ResultList limit;
 
 
         scanner.getNext();
 
-
         Result end = expr();
-        ResultList limit;
+
         if (end instanceof ResultList) {
             limit = (ResultList) end;
         } else {
@@ -1056,7 +1060,7 @@ public class Parser {
 
         }
 
-        ResultValue startValue = limit.getItem(this, 0); //set up iterating char value
+
 
         if (!scanner.currentToken.tokenStr.equals(":")) {
             // TODO: fix exception - error for statement not ending in ':'
@@ -1090,7 +1094,8 @@ public class Parser {
 
         storageManager.updateVariable(controlVar, startValue);
 
-        while(Utility.lessThan(this, currPos, maxPos).strValue.equals("T")) {
+        while(Utility.lessThan(this, currPos, maxPos).strValue.equals("T") &&
+                (result.execMode == iExecMode.EXECUTE || result.execMode == iExecMode.CONTINUE_EXEC)) {
             // evaluate loop statements
             result = statements(execMode);
 
@@ -1127,6 +1132,7 @@ public class Parser {
         }
 
         result = statements(iExecMode.IGNORE_EXEC);
+        result.execMode = execMode;
 
         if (!result.terminatingString.equals("endfor")) {
             //TODO: fix exception - end should be here
@@ -1234,7 +1240,8 @@ public class Parser {
 
 
 
-        while (Utility.lessThan(this, startValue, limit).strValue.equals("T") && result.execMode == iExecMode.EXECUTE) {
+        while (Utility.lessThan(this, startValue, limit).strValue.equals("T") &&
+                (result.execMode == iExecMode.EXECUTE || result.execMode == iExecMode.CONTINUE_EXEC)) {
             // evaluate statments
             result = statements(execMode);
 

--- a/pickle/Parser.java
+++ b/pickle/Parser.java
@@ -891,9 +891,9 @@ public class Parser {
                         if (entry.primClassif != Classif.EMPTY) {
                             STIdentifier id = (STIdentifier) entry;
                             if ((id.dclType == SubClassif.STRING || id.dclType == SubClassif.DATE) && !id.structure.equals("array")) {
-                                result = charStringFor(controlVar);
+                                result = charStringFor(controlVar, execMode);
                             } else if (id.structure.equals("array")) {
-                                result = itemArrayFor(controlVar);
+                                result = itemArrayFor(controlVar, execMode);
                             } else {
                                 // TODO: 4/15/2021 cannot run for loop on any other types
                                 throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Identifier must be of type String, Int, Float to use for loop");
@@ -902,7 +902,7 @@ public class Parser {
                             throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Cannot find value for Identifier");
                         }
                     }else if (scanner.nextToken.subClassif == SubClassif.STRING || scanner.nextToken.subClassif == SubClassif.DATE) {
-                        charStringFor(controlVar);
+                        result = charStringFor(controlVar, execMode);
                     } else {
                         throw new ScannerParserException(scanner.nextToken, scanner.sourceFileNm, "Cannot run for loop on constant value " + scanner.nextToken.subClassif.name());
                     }

--- a/pickle/Parser.java
+++ b/pickle/Parser.java
@@ -1253,8 +1253,10 @@ public class Parser {
             scanner.getNext();
         }
 
-        ResultValue rest = statements(iExecMode.IGNORE_EXEC);
-        result.terminatingString = rest.terminatingString;
+        // get rest of for loop body
+        // consume whether break or continue hit and pass execMode out to caller
+        result = statements(iExecMode.IGNORE_EXEC);
+        result.execMode = execMode;
 
         if (!result.terminatingString.equals("endfor")) {
             // TODO: 4/13/2021 throw error

--- a/pickle/ResultValue.java
+++ b/pickle/ResultValue.java
@@ -10,6 +10,7 @@ public class ResultValue implements Result {
     public SubClassif dataType;
     public String strValue;
     public String terminatingString;
+    public iExecMode execMode;
 
     public ResultValue(String strValue, SubClassif dataType)
     {

--- a/pickle/SymbolTable.java
+++ b/pickle/SymbolTable.java
@@ -62,6 +62,8 @@ public class SymbolTable {
 		this.globalST.put("endfor", new STControl("endfor", Classif.CONTROL, SubClassif.END));
 		this.globalST.put("while", new STControl("while", Classif.CONTROL, SubClassif.FLOW));
 		this.globalST.put("endwhile", new STControl("endwhile", Classif.CONTROL, SubClassif.END));
+		this.globalST.put("break", new STControl("break", Classif.CONTROL, SubClassif.FLOW));
+		this.globalST.put("continue", new STControl("continue", Classif.CONTROL, SubClassif.FLOW));
 		this.globalST.put("Int", new STControl("Int", Classif.CONTROL, SubClassif.DECLARE));
 		this.globalST.put("Float", new STControl("Float", Classif.CONTROL, SubClassif.DECLARE));
 		this.globalST.put("String", new STControl("String", Classif.CONTROL, SubClassif.DECLARE));

--- a/pickle/iExecMode.java
+++ b/pickle/iExecMode.java
@@ -1,0 +1,9 @@
+package pickle;
+
+public enum iExecMode {
+
+    IGNORE_EXEC,
+    EXECUTE,
+    BREAK_EXEC,
+    CONTINUE_EXEC
+}


### PR DESCRIPTION
Add all functionality for break and continue statements for pickle interpreter. Currently, works for while loop and all for loop styles. Major logic changes to statements function. Also needed to modify how all for loops were returning execution mode due to bug that was passing incorrect execution mode out skipping statements following a nested for or while loop. This should encapsulate all functionality for currently implemented statements and close #38. Follow current design pattern of if block for when implementing select statement block


Adds following statements:
 - break
     - causes program execution to exit immediately surrounding for or while
     - does not propagate execution to outer for or while blocks
 - continue
     - branch to the bottom of the for or while and continue loop
     - does not propagate execution to outer for or while blocks




Output of p5Break.txt:
```
p5Break.txt 
i= 1 
it is a fruit 
i is <= 2 
inside while, after first inner if 
it is pike 
i= 2 
it is a fruit 
i is <= 2 
inside while, after first inner if 
it is pike 
i= 3 
it is a fruit 
i is greater than 2 
after while loop i= 3 
Unsorted array 
	 60 
	 30 
	 20 
	 10 
	 5 
	 50 
	 70 
	 25 
	 35 
	 45 
	 15 
Nested for loops, sorting the array 
	ready to leave, i= 8 
sorted array 
	 5 
	 10 
	 15 
	 20 
	 25 
	 30 
	 35 
	 45 
	 50 
	 60 
	 70 
```